### PR TITLE
对于前后端信号发送方式的更改

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -63,6 +63,8 @@ def result():
             true_num = true_num + 1 if res_correct else true_num
             gt = " ".join(labels[display_seq[display_idx]])
             send_msg(res, gt, str(res_correct), f"{fps_all:0.2f}", f"{true_num / test_num:0.4f}", test_num, cpu, mem, f"{fps:0.2f}")
+            time.sleep(display_delay) # 延时display_delay后通知树莓派
+            socketio.emit('pi', "new image")  # 向树莓派发送pi信号说明图片已更新
         else:
             error = 'invalid post'
     return "ok"
@@ -73,13 +75,19 @@ def handle_message(message):
     print('received message: ' + message)
     send_msg()
 
-@socketio.on('pi')
-def handle_message(message):
-    # 收到浏览器更新图片的通知，等待display_delay(s)后通知树莓派识别图像
-    global start_time, display_delay
-    time.sleep(display_delay)
+# @socketio.on('pi')
+# def handle_message(message):
+#     # 收到浏览器更新图片的通知，等待display_delay(s)后通知树莓派识别图像
+#     global start_time, display_delay
+#     time.sleep(display_delay)
+#     socketio.emit('pi', "new image")
+#     # start_time = time.time()
+
+# 手动向树莓派发送更新提示
+@socketio.on('ask')
+def ask_pi(message):
     socketio.emit('pi', "new image")
-    # start_time = time.time()
+
 
 @socketio.on('reset')
 def handle_message(message):

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -19,6 +19,7 @@
     </div>
     <div style="width:100%;text-align:center;">
       <button id="start_button" type="button">Reset</button>
+      <button id="continue_button" type="button">Ask PI</button>
     </div>
     <div style="width:100%;text-align:center;position:relative;top:30%;">
       <form>
@@ -48,10 +49,14 @@
     document.getElementById("cpu").innerHTML = data.cpu;
     document.getElementById("mem").innerHTML = data.mem;
     document.getElementById("img").src = data.img_url;
-    socket.emit('pi', "new image");
+    // socket.emit('pi', "new image"); // 取消前端发送pi信号
   });
   document.getElementById("start_button").onclick = function() {
     socket.emit('reset', "Reset and start!");
+  };
+  document.getElementById("continue_button").onclick = function() {
+    // 手动提示树莓派图片已更新
+    socket.emit('ask', "Ask PI!")
   }
   document.getElementById("button").onclick = function() {
       document.getElementById("img").style.width = document.getElementById("width").value;


### PR DESCRIPTION
我采用的是`openvino`的计算棒模型，性能提高了，实测每秒能处理16帧左右。在这样的情况下，整个系统跑起来之后发现前端更新图片非常快（1秒十几张，更新不均匀），和识别结果的更新不同步，增大`display_delay`到几秒后仍是一样；并且图片是分批更新的，第一次更新几张，然后再更新十几张，然后二十几张，……
后端打log发现前端的`socketio.emit('pi')`（向后端发送更新图片的信号）不正常，且单位时间内发得越来越多。具体原因没有石锤，猜想原因可能有二
一是因为网络原因`emit`没有响应所以多发了几次，或者是别的奇怪的原因。
二是因为后端`@socketio.on('pi')`的处理中也会`socketio.emit('pi')`（虽然这个是发给树莓派通知图片已更新的信号，但和前端发的信号名字一样）导致这个信号越来越多（把这个名字改成别的比如`socketio.emit('piemb')`有所缓解但还是有前后端结果更新不同步的问题，所以最后的解决方案如下）

一、前端不再发通知后端图片已更新的信号pi。
二、在`result()`函数中，后端每次处理树莓派的post，处理树莓派的结果，然后提示前端更新图片。（和原来一样）；然后延时`display_delay`，（为了等待前端加载图片完成），然后再发`socketio.emit('pi')`，通知树莓派新的图片加载完成，开始下一张图片的识别，形成循环

最后，前端增加了一个`ask pi`按钮，用来要求后端，使后端给树莓派发一个信号，开始第一张图片的识别（而且如果树莓派的post中断，上述循环也会中断，也可以按这个按钮来继续要求树莓派识别，从而继续上述识别的循环）